### PR TITLE
Add initial Face3 support

### DIFF
--- a/core_face3.go
+++ b/core_face3.go
@@ -1,0 +1,15 @@
+package three
+
+import "github.com/gopherjs/gopherjs/js"
+
+// Face3 is a triangular face used in Geometry. These are created automatically for all standard geometry types, however if you are building a custom geometry you will have to create them manually.
+type Face3 struct {
+	*js.Object
+}
+
+// NewFace3 creates new Face3 object with defaults for normal, color and material.
+func NewFace3(a, b, c float64) Face3 {
+	return Face3{
+		Object: three.Get("Face3").New(a, b, c),
+	}
+}


### PR DESCRIPTION
This PR adds very basic support for [Face3](https://threejs.org/docs/#api/en/core/Face3) core primitive.

JS constructor uses overloading to specify additional parameters such as `normal`, `color` and `materialIndex`. I think the best way to deal with converting overloaded constructors to Go is to add setters for those optional values. However, I'm not implementing them in this PR, as I don't need this for my use cases and not sure I can properly test it. They always can be added later once someone actually needs them.